### PR TITLE
Take the "to" path into account when creating directories

### DIFF
--- a/lib/onezip.js
+++ b/lib/onezip.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs-extra');
+const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const Emitter = require('events').EventEmitter;

--- a/lib/onezip.js
+++ b/lib/onezip.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const util = require('util');
 const Emitter = require('events').EventEmitter;
@@ -251,7 +251,7 @@ OneZip.prototype._extract  = function(from) {
             };
             
             if (/\/$/.test(fileName))
-                return mkdirp(fileName, fn);
+                return mkdirp(path.join(this._to, fileName), fn);
             
             zipfile.openReadStream(entry, this._onOpenReadStream((readStream) => {
                 this._writeFile(fileName, readStream, fn);
@@ -265,7 +265,7 @@ OneZip.prototype._extract  = function(from) {
 };
 
 OneZip.prototype._writeFile = function(fileName, readStream, fn) {
-    mkdirp(path.dirname(fileName), (error) => {
+    mkdirp(path.dirname(path.join(this._to, fileName)), (error) => {
         if (error)
             return fn(error);
         


### PR DESCRIPTION
So I was trying this lib out and noticed that a simple `from -> to` extract operation failed:
```js
onezip.extract(from, to);
```
It seemed like the lib just created the directories in the current working directory, not taking into account the target base path.

I am using Windows 10, but I would assume the same problem persists over different platforms. 